### PR TITLE
Mention Node 7 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > Async await wrapper for easy error handling
 
 ## Pre-requisites
-You need to use Node 7+ or an ES7 transpiler in order to use async/await functionality.
+You need to use Node 7.6 (or later) or an ES7 transpiler in order to use async/await functionality.
 You can use babel or typescript for that.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > Async await wrapper for easy error handling
 
 ## Pre-requisites
-You need ES7 transpiler in order to use async/await functionality.
+You need to use Node 7+ or an ES7 transpiler in order to use async/await functionality.
 You can use babel or typescript for that.
 
 ## Install


### PR DESCRIPTION
async/await works natively in Node 7, it's a shame to at least not mention it as an option. :)