### PR TITLE
Unused/Undeclared variable in README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import to from 'await-to-js';
 // const to = require('await-to-js').default;
 
 async function asyncTaskWithCb(cb) {
-     let err, user, savedUser, notification;
+     let err, user, savedTask, notification;
 
      [ err, user ] = await to(UserModel.findById(1));
      if(!user) return cb('No user found');


### PR DESCRIPTION
Replaced `savedUser` with `savedTask` in declaration.