### PR TITLE
refactor: add early return from catch with an immutable object

### DIFF
--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -11,7 +11,8 @@ export function to<T, U = Error> (
     .then<[null, T]>((data: T) => [null, data])
     .catch<[U, undefined]>((err: U) => {
       if (errorExt) {
-        Object.assign(err, errorExt);
+        const parsedError = Object.assign({}, err, errorExt);
+        return [parsedError, undefined];
       }
 
       return [err, undefined];


### PR DESCRIPTION
Currently, we use copy errorExt to the err object if we have an errorExt.
This is cleaner, more functional and more understandable with an early return