### PR TITLE
Correct typings to use tuples.

### DIFF
--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -3,10 +3,10 @@
  * @param { Object= } errorExt - Additional Information you can pass to the err object
  * @return { Promise }
  */
-export function to<T, U = Error> (
+export function to<T, U = Error>(
   promise: Promise<T>,
-  errorExt?: object
-): Promise<[U | null, T | undefined]> {
+  errorExt?: object,
+): Promise<[U, undefined] | [null, T]> {
   return promise
     .then<[null, T]>((data: T) => [null, data])
     .catch<[U, undefined]>((err: U) => {


### PR DESCRIPTION
The previous type `() => Promise<[U | null, undefined | T]>` is incorrect, as it allows for typings such as `[U, T]` which is an impossible result.

Changing this type to be `() => Promise<[U, undefined] | [null, T]>` correctly characterises the possible type results.