### PR TITLE
Make the type of the return value more precise

### DIFF
--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -6,7 +6,7 @@
 export function to<T, U = Error> (
   promise: Promise<T>,
   errorExt?: object
-): Promise<[U, undefined]> | Promise<[null, T]> {
+): Promise<[U, undefined] | [null, T]> {
   return promise
     .then<[null, T]>((data: T) => [null, data])
     .catch<[U, undefined]>((err: U) => {

--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -6,7 +6,7 @@
 export function to<T, U = Error> (
   promise: Promise<T>,
   errorExt?: object
-): Promise<[U | null, T | undefined]> {
+): Promise<[U, undefined]> | Promise<[null, T]> {
   return promise
     .then<[null, T]>((data: T) => [null, data])
     .catch<[U, undefined]>((err: U) => {


### PR DESCRIPTION
If the first return value (error) is null, then this change implies that the second return value is not `undefined`.

It solves a problem I was facing: getting `Type 'APIResponse<any> | undefined' is not assignable to type 'APIResponse<any>'` type error on the last row of the following Vuex (with vuex-module-decorators) example:
```js
    @Action({ rawError: true })
    public async deleteAsset(asset: Asset): Promise<APIResponse> {
      this.context.commit('setIsLoading', true);
      const [err, response] = await to(deleteAsset(asset));
      this.context.commit('setIsLoading', false);
      if (err) {
        throw err;
      }   
      this.context.commit('setAssetDeleted', asset);
      return response;
    }
```