### PR TITLE
fix: add readonly to promise type for flexibility

### DIFF
--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -1,10 +1,10 @@
 /**
- * @param { Promise } promise
+ * @param { Readonly<Promise> } promise
  * @param { Object= } errorExt - Additional Information you can pass to the err object
  * @return { Promise }
  */
 export function to<T, U = Error> (
-  promise: Promise<T>,
+  promise: Readonly<Promise<T>>,
   errorExt?: object
 ): Promise<[U, undefined] | [null, T]> {
   return promise


### PR DESCRIPTION
When using this library with [`algoliasearch`](https://github.com/algolia/algoliasearch-client-javascript) (whose return types are always [`Readonly<Promise<T>>`](https://github.com/algolia/algoliasearch-client-javascript/blob/master/packages/client-common/src/types/WaitablePromise.ts)), I've had to use a wrapper function so that I can update those types.

This allows for more flexibility (i.e. by reducing the required properties on the `Promise` object) and for use with more restrictive libraries like `algoliasearch`.