### PR TITLE
refactor: remove response undefined type

### DIFF
--- a/src/await-to-js.ts
+++ b/src/await-to-js.ts
@@ -6,16 +6,16 @@
 export function to<T, U = Error> (
   promise: Promise<T>,
   errorExt?: object
-): Promise<[U, undefined] | [null, T]> {
+): Promise<[U, T] | [null, T]> {
   return promise
     .then<[null, T]>((data: T) => [null, data])
-    .catch<[U, undefined]>((err: U) => {
+    .catch<[U, T]>((err: U) => {
       if (errorExt) {
         const parsedError = Object.assign({}, err, errorExt);
-        return [parsedError, undefined];
+        return [parsedError, null as T];
       }
 
-      return [err, undefined];
+      return [err, null as T];
     });
 }
 


### PR DESCRIPTION
Hi!

This pull request follows from this issue https://github.com/scopsy/await-to-js/issues/14

```Typescript
const [error, response] = await to<ResponseDTO>(myApiCall());
// expect response as ResponseDTO, receive ResponseDTO | undefined
```