### PR TITLE
Supports importing using the default option in Node.js ESM modu…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "await-to-js",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.1",
+      "name": "await-to-js",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
   ],
   "main": "dist/await-to-js.umd.js",
   "module": "dist/await-to-js.es5.js",
+  "exports": {
+    ".": {
+      "import": "./dist/await-to-js.es5.js",
+      "require": "./dist/await-to-js.umd.js",
+      "typings": "./dist/types/await-to-js.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "typings": "dist/types/await-to-js.d.ts",
   "homepage": "https://github.com/scopsy/await-to-js#readme",
   "files": [


### PR DESCRIPTION
Using the default imported `to` function in a Node.js esm module will result in an error
> TypeError: to is not a function
This change ensures backward compatibility with all import syntaxes.

